### PR TITLE
Added 1 new prop and 1 bug fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ export default class ScrollPicker extends Component {
         style:ViewPropTypes.style,
         dataSource:PropTypes.array.isRequired,
         selectedIndex:PropTypes.number,
+        animateToSelectedIndex:PropTypes.bool,
         onValueChange:PropTypes.func,
         renderItem:PropTypes.func,
         highlightColor:PropTypes.string,
@@ -44,7 +45,7 @@ export default class ScrollPicker extends Component {
     componentDidMount(){
         if(this.props.selectedIndex){
             setTimeout(() => {
-                this.scrollToIndex(this.props.selectedIndex);
+                this.scrollToIndex(this.props.selectedIndex, this.props.animateToSelectedIndex);
             }, 0);
         }
     }
@@ -180,12 +181,12 @@ export default class ScrollPicker extends Component {
         }
     }
 
-    scrollToIndex(ind){
+    scrollToIndex(ind, animated = true){
         this.setState({
             selectedIndex:ind,
         });
         let y = this.itemHeight * ind;
-        this.sview.scrollTo({y:y});
+        this.sview.scrollTo({y:y, aniamted});
     }
 
     getSelected(){

--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ export default class ScrollPicker extends Component {
             selectedIndex:ind,
         });
         let y = this.itemHeight * ind;
-        this.sview.scrollTo({y:y, aniamted});
+        this.sview.scrollTo({y:y, animated});
     }
 
     getSelected(){

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ export default class ScrollPicker extends Component {
                 <ScrollView
                     ref={(sview) => { this.sview = sview; }}
                     bounces={false}
-                    showsVerticalScrollIndicator={false}
+                    showsVerticalScrollIndicator={false} 
                     nestedScrollEnabled={true}
                     onMomentumScrollBegin={this._onMomentumScrollBegin.bind(this)}
                     onMomentumScrollEnd={this._onMomentumScrollEnd.bind(this)}

--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ export default class ScrollPicker extends Component {
                     ref={(sview) => { this.sview = sview; }}
                     bounces={false}
                     showsVerticalScrollIndicator={false}
+                    nestedScrollEnabled={true}
                     onMomentumScrollBegin={this._onMomentumScrollBegin.bind(this)}
                     onMomentumScrollEnd={this._onMomentumScrollEnd.bind(this)}
                     onScrollBeginDrag={this._onScrollBeginDrag.bind(this)}


### PR DESCRIPTION
New Prop: We did not like that if we set the selectedIndex it was always animated. So we added a prop called animateToSelectedIndex which allows the user to determine if it should be animated. The default is true.

Bug Fix: On Android, if the ScrollPicker was nested inside another ScrollView, it would not scroll. So simply added showsVerticalScrollIndicator={false} to the ScrollView to resolve this issue.